### PR TITLE
check-backups.sh now check the status of the backup script

### DIFF
--- a/scripts/check-backups.sh
+++ b/scripts/check-backups.sh
@@ -41,3 +41,18 @@ fi
 
 rm $ERROR_FILE
 
+# Test for status of files and database backups (/usr/local/pf/addons/database-backup-and-maintenance.sh)
+statusFiles=( "/usr/local/pf/var/backup_files.status" "/usr/local/pf/var/backup_db.status" )
+for i in "${statusFiles[@]}"
+do
+if ! [ -f $i ]; then
+  echo "PacketFence backup status file '$i' does not exists"
+  exit 1
+fi
+error=($(awk '!/^OK$/' $i))
+if [ $error ]; then
+    echo "$(cat $i)"
+    exit 1
+fi
+done
+


### PR DESCRIPTION
Added a check in check-backups.sh for the output value of the database backup script.

Do not merge before merging https://github.com/inverse-inc/packetfence/pull/1904

Take note of the "require root" attribute that was already present in this script. We may want to discuss this since the check won't run if do not have root permission even if that part of the check does not require root permissions.

Also, take note that PacketFence setups running a previous database-backup-and-maintenance script will throw an error.