### PR TITLE
Check domain join on remote systems

### DIFF
--- a/monit-script-registry.txt
+++ b/monit-script-registry.txt
@@ -19,3 +19,4 @@ http://inverse.ca/downloads/PacketFence/monitoring-scripts/v1/scripts/check-2502
 http://inverse.ca/downloads/PacketFence/monitoring-scripts/v1/scripts/check-wsrep-members.sh
 http://inverse.ca/downloads/PacketFence/monitoring-scripts/v1/scripts/check-mysql-binary-log.sh
 http://inverse.ca/downloads/PacketFence/monitoring-scripts/v1/scripts/check-epel.sh
+http://inverse.ca/downloads/PacketFence/monitoring-scripts/v1/scripts/check-domain-join.sh

--- a/scripts/check-domain-join.sh
+++ b/scripts/check-domain-join.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#fname:check-domain-join.sh
+#as-root
+
+error=0
+
+# by default, we check domain in chroot
+CHECK_CHROOT_JOIN="${CHECK_CHROOT_JOIN:-"1"}"
+CHECK_SYSTEM_JOIN="${CHECK_SYSTEM_JOIN:-"0"}"
+
+function check_domain_join_in_chroot {
+    domains=$(perl -I/usr/local/pf/lib -Mpf::config -e "print join(' ', keys(%pf::config::ConfigDomain))")
+    for domain in $domains; do
+        /sbin/ip netns exec $domain /usr/sbin/chroot /chroots/$domain wbinfo -t > /dev/null 2>&1
+        rc=$?
+        # check return code of wbinfo -t
+        if [ "$rc" -ne 0 ]; then
+            echo "$domain domain: wbinfo -t failed";
+            error=1
+        fi
+    done
+}
+
+# if we check directly on OS, there is only one domain
+function check_domain_join {
+        wbinfo -t > /dev/null 2>&1
+        rc=$?
+        # check return code of wbinfo -t
+        if [ "$rc" -ne 0 ]; then
+            echo "$domain domain: wbinfo -t failed";
+            error=1
+        fi
+    done
+}
+
+if [ "$CHECK_CHROOT_JOIN" -eq 1 ]; then
+  check_domain_join_in_chroot
+fi
+
+if [ "$CHECK_SYSTEM_JOIN" -eq 1 ]; then
+  check_domain_join
+fi
+
+exit $error


### PR DESCRIPTION
This script use `wbinfo -t` command to check domain join on remote systems for all domains defined in `domain.conf`.

By default, it will run command in chroot(s) but you can simply change this behavior by doing `export CHECK_SYSTEM_JOIN=1`