### PR TITLE
Adjustements related to PacketFence v11

### DIFF
--- a/scripts/check-samba-machine-password-timeout.sh
+++ b/scripts/check-samba-machine-password-timeout.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #fname:check-samba-machine-password-timeout.sh
 
-domains=`perl -I/usr/local/pf/lib -Mpf::config -e "print join(' ', keys(%pf::config::ConfigDomain))"`
+domains=`perl -I/usr/local/pf/lib_perl/lib/perl5 -I/usr/local/pf/lib -Mpf::config -e "print join(' ', keys(%pf::config::ConfigDomain))"`
 
 error=0
 

--- a/scripts/check-sysctl.sh
+++ b/scripts/check-sysctl.sh
@@ -2,14 +2,14 @@
 #fname:check-sysctl.sh
 
 # Passthrough test
-if [ `perl -I/usr/local/pf/lib -Mpf::db -e 'print scalar(keys(%pf::config::ConfigDomain))'` -ge 1 ] ; then
+if [ `perl -I/usr/local/pf/lib_perl/lib/perl5 -I/usr/local/pf/lib -Mpf::db -e 'print scalar(keys(%pf::config::ConfigDomain))'` -ge 1 ] ; then
     if [ `/sbin/sysctl -e -n net.ipv4.ip_forward` -eq 0 ] ; then
       echo "The passthroughs and the Multi-domain configuration won't work, net.ipv4.ip_forward = 0"
       exit 1
     fi
 fi
 # Active-Active mode test
-if [ `perl -I/usr/local/pf/lib -Mpf::db -e 'print scalar(@pf::cluster::cluster_hosts)'` -ge 1 ] ; then
+if [ `perl -I/usr/local/pf/lib_perl/lib/perl5 -I/usr/local/pf/lib -Mpf::db -e 'print scalar(@pf::cluster::cluster_hosts)'` -ge 1 ] ; then
     if [ `/sbin/sysctl -e -n net.ipv4.ip_nonlocal_bind` -eq 0 ] ; then
       echo "Server not configured properly for Active-Active Cluster, net.ipv4.ip_nonlocal_bind = 0"
       exit 1

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -65,10 +65,10 @@ osdetect(){
 export -f osdetect
 
 dbparams(){
-    DB_USER=$(perl -I/usr/local/pf/lib -Mpf::db -e 'print $pf::db::DB_Config->{user}')
-    DB_PWD=$(perl -I/usr/local/pf/lib -Mpf::db -e 'print $pf::db::DB_Config->{pass}')
-    DB_NAME=$(perl -I/usr/local/pf/lib -Mpf::db -e 'print $pf::db::DB_Config->{db}')
-    DB_HOST=$(perl -I/usr/local/pf/lib -Mpf::db -e 'print $pf::db::DB_Config->{host}')
+    DB_USER=$(perl -I/usr/local/pf/lib_perl/lib/perl5 -I/usr/local/pf/lib -Mpf::db -e 'print $pf::db::DB_Config->{user}')
+    DB_PWD=$(perl -I/usr/local/pf/lib_perl/lib/perl5 -I/usr/local/pf/lib -Mpf::db -e 'print $pf::db::DB_Config->{pass}')
+    DB_NAME=$(perl -I/usr/local/pf/lib_perl/lib/perl5 -I/usr/local/pf/lib -Mpf::db -e 'print $pf::db::DB_Config->{db}')
+    DB_HOST=$(perl -I/usr/local/pf/lib_perl/lib/perl5 -I/usr/local/pf/lib -Mpf::db -e 'print $pf::db::DB_Config->{host}')
     export DB_USER
     export DB_PWD
     export DB_NAME
@@ -115,14 +115,14 @@ galera_enabled() {
 export -f galera_enabled
 
 cluster_members() {
-    CLUSTER_MEMBERS=`perl -I/usr/local/pf/lib -Mpf::cluster -e 'print join(", ", map { $_->{host} . ":" . $_->{management_ip} } @cluster_servers)'`
+    CLUSTER_MEMBERS=`perl -I/usr/local/pf/lib_perl/lib/perl5 -I/usr/local/pf/lib -Mpf::cluster -e 'print join(", ", map { $_->{host} . ":" . $_->{management_ip} } @cluster_servers)'`
     export CLUSTER_MEMBERS
 }
 
 export -f cluster_members
 
 cluster_members_count() {
-    CLUSTER_MEMBERS_COUNT=`perl -I/usr/local/pf/lib -Mpf::cluster -e 'print scalar @cluster_servers'`
+    CLUSTER_MEMBERS_COUNT=`perl -I/usr/local/pf/lib_perl/lib/perl5 -I/usr/local/pf/lib -Mpf::cluster -e 'print scalar @cluster_servers'`
     export CLUSTER_MEMBERS_COUNT
 }
 


### PR DESCRIPTION
### Changes

- Update paths used by Perl commands

### Notes

- `run-all.sh` show following error on EL8:
```
2021-08-13 09:27:12,174 [ERROR] yum:15148:MainThread @logutil.py:194 - [Errno 13] Permission denied: '/var/log/rhsm/rhsm.log' - Further logging output will be written to stderr
2021-08-13 09:27:12,177 [ERROR] yum:15148:MainThread @identity.py:156 - Reload of consumer identity cert /etc/pki/consumer/cert.pem raised an exception with msg: [Errno 13] Permission denied: '/etc/pki/consumer/key.pem'
```
because `check-epel.sh` is run as `pf-monitoring` but it doesn't exit with an error code different from zero.
