### PR TITLE
Fix for awk on debian

### DIFF
--- a/scripts/check-certs.sh
+++ b/scripts/check-certs.sh
@@ -8,15 +8,29 @@ CERTS=()    # Will hold "due to expire" certificates
 # RADIUS certificates
 # Checks for 'certificate_file =' in '/usr/local/pf/raddb/mods-enabled/eap' or in '/usr/local/pf/raddb/eap.conf'
 
-if [ -f /usr/local/pf/raddb/eap.conf ] ; then
-    files=($(awk '$1 !~ /^\#/ && /certificate_file =/{print substr($0, index($0,$3))}' /usr/local/pf/raddb/eap.conf))
-else
-    files=($(awk '$1 !~ /^\#/ && /certificate_file =/{print substr($0, index($0,$3))}' /usr/local/pf/raddb/mods-enabled/eap))
-fi
+osdetect
 
-# HTTPd certificates
-# Checks for 'SSLCertificateFile' in '/usr/local/pf/var/conf/ssl-certificates.conf'
-files+=($(awk '$1  !~ /^\#/ && /SSLCertificateFile/{print substr($0, index($0,$2))}' /usr/local/pf/var/conf/ssl-certificates.conf))
+if [ $DistroBasedOn == "redhat" ]; then
+    if [ -f /usr/local/pf/raddb/eap.conf ] ; then
+        files=($(awk '$1 !~ /^\#/ && /certificate_file =/{print substr($0, index($0,$3))}' /usr/local/pf/raddb/eap.conf))
+    else
+        files=($(awk '$1 !~ /^\#/ && /certificate_file =/{print substr($0, index($0,$3))}' /usr/local/pf/raddb/mods-enabled/eap))
+    fi
+
+    # HTTPd certificates
+    # Checks for 'SSLCertificateFile' in '/usr/local/pf/var/conf/ssl-certificates.conf'
+    files+=($(awk '$1  !~ /^\#/ && /SSLCertificateFile/{print substr($0, index($0,$2))}' /usr/local/pf/var/conf/ssl-certificates.conf))
+else
+    if [ -f /usr/local/pf/raddb/eap.conf ] ; then
+        files=($(awk '$1 !~ /^#/ && /certificate_file =/{print substr($0, index($0,$3))}' /usr/local/pf/raddb/eap.conf))
+    else
+        files=($(awk '$1 !~ /^#/ && /certificate_file =/{print substr($0, index($0,$3))}' /usr/local/pf/raddb/mods-enabled/eap))
+    fi
+
+    # HTTPd certificates
+    # Checks for 'SSLCertificateFile' in '/usr/local/pf/var/conf/ssl-certificates.conf'
+    files+=($(awk '$1  !~ /^#/ && /SSLCertificateFile/{print substr($0, index($0,$2))}' /usr/local/pf/var/conf/ssl-certificates.conf))
+fi
 
 # Check for validity
 for i in "${files[@]}"


### PR DESCRIPTION
Avoid warning:

/usr/local/pf/var/monitoring-scripts/.check-certs.sh                                                                                     
awk: cmd. line:1: warning: regexp escape sequence `\#' is not a known regexp operator
